### PR TITLE
docs: links, typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **WCS** is made utilizing **[Typescript](<https://typescriptlang.org/>)** and compiled to luau using **[roblox-ts](<https://roblox-ts.com/>)**. It provides support for
 [roblox-ts](<https://roblox-ts.com/>) users and [luau](<https://luau-lang.org/>) users,
-by prodiving type definitions for both languages.
+by providing type definitions for both languages.
 
 Please give feedback
 
-[**Documentation**](<https://g1mmethemoney.github.io/WCS/>)
-[**Github Repository**](<https://github.com/g1mmethemoney/WCS>)
+[**Documentation**](<https://wad4444.github.io/WCS/>)
+[**GitHub Repository**](<https://github.com/wad4444/WCS>)


### PR DESCRIPTION
Seems like the GitHub account name changed, so the links in the README broke. Lmk if anything to fix